### PR TITLE
Fix namespace 'NUnit' not found on version 0.3.0

### DIFF
--- a/Tests/Supyrb.Signals.Tests.asmdef
+++ b/Tests/Supyrb.Signals.Tests.asmdef
@@ -1,23 +1,13 @@
 {
     "name": "Supyrb.Signals.Tests",
     "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner",
         "Supyrb.Signals"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
     ],
     "includePlatforms": [
         "Editor"
     ],
-    "excludePlatforms": [],
-    "allowUnsafeCode": false,
-    "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
-    "autoReferenced": false,
-    "defineConstraints": [
-        "UNITY_INCLUDE_TESTS"
-    ],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "excludePlatforms": []
 }


### PR DESCRIPTION
I tried to use the 0.3.0 version as a package in Unity 2018.4.15 but got compiling errors:

`The type or namespace name 'NUnit' could not be found (are you missing a using directive or an assembly reference?)`

I fixed it by removing the TestRunner and nunit.framework.dll references on the Tests assembly file and checked the Tests assemblies check mark.